### PR TITLE
Inline count using the old query

### DIFF
--- a/src/ts/controller.ts
+++ b/src/ts/controller.ts
@@ -22,10 +22,13 @@ export class ProductsController extends ODataController {
                 .sort(mongodbQuery.sort)*/
                 .toArray();
         if (mongodbQuery.inlinecount){
-            (<any>result).inlinecount = await db.collection("Products")
-                    .find(mongodbQuery.query)
-                    .project(mongodbQuery.projection)
-                    .count(false);
+            mongodbQuery.aggregation.push({
+                $count: 'count_sum'
+            });
+            let countResult:any = await db.collection("properties_idx")
+                .aggregate(mongodbQuery.aggregation)
+                .toArray();
+            (<any>result).inlinecount = countResult[0].count_sum;
         }
         return result;
     }


### PR DESCRIPTION
This is a problem if you use any of the odata operators that depend on the new aggregation stuff. 

I must admit changing the aggregation stuff like this might be considered bad form, maybe clone it instead? It probably should never be a problem however since it's the last thing that uses the aggregation object.